### PR TITLE
fix build error

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,12 +27,13 @@ const siteConfig = {
 
   themeConfig: {
     navbar: {
+      title: ' ',
       logo: {
         alt: 'EOS Costa Rica Logo',
         src: 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent.png',
         srcDark: 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent-white.png'
       },
-      links: [
+      items: [
         /*{
           href: 'https://guias.eoscostarica.io/',
           label: 'Inicio',
@@ -53,8 +54,7 @@ const siteConfig = {
       logo: {
         alt: 'EOS Costa Rica Logo',
         src: 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent.png',
-        srcDark: 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent-white.png',
-        href: 'https://guias.eoscostarica.io/',
+        href: 'https://guias.eoscostarica.io/'
       },
       links: [
         {


### PR DESCRIPTION
### GH Issue
I encountered the following build errors

```
$ docusaurus build
Creating an optimized production build...
ValidationError: themeConfig.navbar.links has been renamed as themeConfig.navbar.items
error Command failed with exit code 1.
```


```
$ docusaurus build
Creating an optimized production build...
ValidationError: "navbar.title" is required
error Command failed with exit code 1.
```


```
$ docusaurus build
Creating an optimized production build...
ValidationError: "footer.logo.srcDark" is not allowed
error Command failed with exit code 1.
```