### PR TITLE
fix(ref): fallo-ref-tutoriales

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -194,7 +194,7 @@ const CardsSection = () => {
         <CustomCard 
           title="Tutoriales"
           body= "Información de apoyo necesaria para realizar la instalación y la ejecución de procesos. "
-          href= "docs/aprender-eosio/como-iniciar"
+          href= "docs/tutoriales/como-iniciar"
           img="https://raw.githubusercontent.com/eoscostarica/guias.eoscostarica.io/master/static/img/cards-icons/tutorials.svg"></CustomCard>
       </Grid>
       <Grid item xs={12} sm={12} md={4}>


### PR DESCRIPTION
### GH Issue

Resolves #178  

### Steps to test
1. Load homepage
1. Load tutoriales sections from homepage
1. Check 'Como Iniciar' is referencing correctly

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
