### PR TITLE
fix(frontend): change-articulos-medium

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -254,7 +254,7 @@ const CustomArticle= (props) => {
 const MediumSection = () => {
   return (
     <div className="container section-container">
-       <h1 className="section-tittle">Artículos de Medium</h1>
+       <h1 className="section-tittle">Artículos de blog</h1>
        <Grid
         container
         direction="row"


### PR DESCRIPTION
### GH Issue

Resolves #

### Steps to test
1. Check title "Artículos Medium" in the home guide page is changed to Artículos blog
1.
1.

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
