### PR TITLE
fix(frontend): Add llaves-github in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -35,6 +35,7 @@ module.exports = {
             "tutoriales/tutorial-flujo-trabajo-git",
             "tutoriales/guia-markdown",
             "tutoriales/guia-github" ,
+            "tutoriales/llaves-github",
             "tutoriales/tutorial-react"
 
         ],


### PR DESCRIPTION
### GH Issue

Resolves #237 

### Steps to test
1. Go to sidebar 



#### CheckList
- [ ] add "tutoriales/llaves-github"
