### PR TITLE
Update Telegram Channels ESP

### DIFF
--- a/docs/comunidad/canales-de-telegram.md
+++ b/docs/comunidad/canales-de-telegram.md
@@ -13,8 +13,8 @@ Los canales de Telegram son una herramienta ideal para difundir mensajes a grand
 - [EOS Education](https://t.me/EOSEDU)
 - [EOSIO en Español](https://t.me/eosEs)
 - [EOS London](https://t.me/EOSLondon)
-- [EOS Nairobi](https://t.me/eosnairobike)
 - [Jungle Testnet](https://t.me/jungletestnet)
+- [EOS Nairobi](https://t.me/eosnairobike)
 - [eosDublin](https://t.me/eosdublin)
 - [EOS Detroit](https://t.me/eos_detroit)
 - [EOS Venezuela](https://t.me/eosvenezuela)
@@ -22,32 +22,29 @@ Los canales de Telegram son una herramienta ideal para difundir mensajes a grand
 - [EOS Jobs](https://t.me/eos_jobs)
 - [EOS Project](https://t.me/EOSproject)
 - [EOS Opportunities](https://t.me/eos_opportunities)
-- [Jungle Testnet](https://t.me/jungletestnet)
 
 ## Comunidad EOS Costa Rica
 
-* [LAChhain EOSIO](https://t.me/lacchaineosio)
-* [EOS Surf](https://t.me/eosbeach)
-* [Blockchain Costa Rica](https://t.me/btccr)
+- [LAChhain EOSIO](https://t.me/lacchaineosio)
+- [EOS Surf](https://t.me/eosbeach)
+- [Blockchain Costa Rica](https://t.me/btccr)
 
 ## Comunidad de Desarrolladores
 
 - [EOS Developers](https://t.me/joinchat/DQRZHEPktgcLlyfbl-bDuQ)
 - [EOS Design](https://t.me/EOSdesign)
 - [EOS Dev en Español](https://t.me/eosDevEs)
-- [EOS Block Pros](https://t.me/EOSBlockPros)
 - [EOS Game Developers](https://t.me/EosGameDevelopers)
 - [Bancor Developers](https://t.me/BancorDevelopers)
 - [EOS Kylin Testnet](https://t.me/cryptokylin1en)
 - [EOS Mechanics](https://t.me/EOSMechanics)
-- [DAPP Network Devs](https://t.me/dappnetworkdevs)
 - [EOS Infra](https://t.me/eosinfra)
 - [EOS Ram](https://t.me/eosram)
 - [EOS Hackathon](https://t.me/EOSHackathonFriends)
 
 ## Redes en las que Participamos
+
 - [Bitcoin Libre](https://t.me/bitcoinlibrecomunidad)
 - [Proton](https://t.me/protonxpr)
-- [Wax](https://t.me/wax_io)
 - [Telos](https://t.me/HelloTelos)
-- [Lacchain](https://t.me/lacchaineosio)
+- [Wax](https://t.me/wax_io)


### PR DESCRIPTION
### Update Telegram Channels ESP

Old Telegram channel invites have been updated and a new section for networks we participate has been added

- resolves #321 

### Steps to test
1. Go to https://guias.eoscostarica.io/docs/comunidad/canales-de-telegram and view telegram invites and the new section

#### CheckList
- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [ ] I Ran a spell check

