### PR TITLE
fix(frontend): delete duplicate list

### DIFF
--- a/docs/pautas-para-codigo-abierto.md
+++ b/docs/pautas-para-codigo-abierto.md
@@ -49,24 +49,8 @@ feat/nueva-carateristica-123
   |           |
   |           +-> Descripción corta de la tarea
   |
-  +-> Tipo: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|content|devtools
+  +-> Tipo: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, content, o devtools
 ```
-
-### Tipo
-
-* **build**: Cambios que afectan el sistema de operación o dependencias externas (ejemplo scopes: gulp, broccoli, npm).
-* **chore**: Lo que un usuario no vería (cambios en el proceso de construcción, la configuración, etc).
-* **ci**: Cambios a los scripts y archivos de configuración de CI (ejemplo scopes: Travis, Circle, BrowserStack, SauceLabs).
-* **docs**: Cambios sólo en la documentación.
-* **feat**: Una nueva característica para el usuario.
-* **fix**: Un arreglo de un bug para el usuario.
-* **perf**: Cambio en el código que mejora el rendimiento.
-* **refactor**: Cambio en el código que no arregla un bug ni añade una característica.
-* **revert**: Revierte un commit previo.
-* **style**: Cambios que no afectar en significado del código (espacios en blanco, formato, puntos y comas olvidados, etc).
-* **test**: Añadir pruebas faltantes o corregir las existentes.
-* **content**: Añadir o remover contenido.
-* **devtools**: Heramientas para desarrolladores.
 
 ## Pautas para los Pull Request
 
@@ -134,17 +118,19 @@ Si el commit revierte un commit previo, debe empezar con `revert: `, seguido por
 
 ### Tipo
 
-* **build**: Cambios que afectan el sistema de operación o dependencias externas (ejemplo scopes: gulp, broccoli, npm)
-* **ci**: Cambios a los scripts y archivos de configuración de CI (ejemplo scopes: Travis, Circle, BrowserStack, SauceLabs)
-* **docs**: Cambios sólo en la documentación
-* **feat**: Una nueva característica
-* **fix**: Un arreglo de un bug
-* **perf**: Cambio en el código que mejora el rendimiento
-* **refactor**: Cambio en el código que no arregla un bug ni añade una característica
-* **style**: Cambios que no afectar en significado del código (espacios en blanco, formato, puntos y comas olvidados, etc)
-* **test**: Añadir pruebas faltantes o corregir las existentes
-* **content**: Añadir o remover contenido
-* **devtools**: Heramientas para desarrolladores
+* **build**: Cambios que afectan el sistema de operación o dependencias externas (ejemplo scopes: gulp, broccoli, npm).
+* **chore**: Lo que un usuario no vería (cambios en el proceso de construcción, la configuración, etc).
+* **ci**: Cambios a los scripts y archivos de configuración de CI (ejemplo scopes: Travis, Circle, BrowserStack, SauceLabs).
+* **docs**: Cambios sólo en la documentación.
+* **feat**: Una nueva característica para el usuario.
+* **fix**: Un arreglo de un bug para el usuario.
+* **perf**: Cambio en el código que mejora el rendimiento.
+* **refactor**: Cambio en el código que no arregla un bug ni añade una característica.
+* **revert**: Revierte un commit previo.
+* **style**: Cambios que no afectar en significado del código (espacios en blanco, formato, puntos y comas olvidados, etc).
+* **test**: Añadir pruebas faltantes o corregir las existentes.
+* **content**: Añadir o remover contenido.
+* **devtools**: Heramientas para desarrolladores.
 
 ### Ámbito
 El ámbito es el nombre del componente o servicio que afecta, ejemplo:


### PR DESCRIPTION
### Delete duplicate list

### What does this PR do?

- resolves #[493](https://github.com/eoscostarica/guide.eoscostarica.io/issues/493)

### Steps to test
1. Go to 'Developer Guidelines'
2. Click on 'Open source Guidelines'
3. Go to Branch Naming Convention and the list of types should not appear

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both English and Spanish
- [ ] I Ran a spell check
