### PR TITLE
fix: trailingSlash inside wrong configuration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,7 +135,6 @@ const siteConfig = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} EOS Costa Rica`, // You can also put own HTML here.
     },
-    trailingSlash: false,
     //Algolia integration
     algolia: {
       appId: "BH4D9OD16A",
@@ -145,7 +144,7 @@ const siteConfig = {
       algoliaOptions: {}, // Optional, if provided by Algolia
     },
   },
-
+  trailingSlash: false,
   presets: [
     [
       "@docusaurus/preset-classic",


### PR DESCRIPTION
### TrailingSlash inside wrong configuration

### What does this PR do?

- resolves [#528](https://github.com/eoscostarica/guide.eoscostarica.io/issues/528)

### Steps to test
1. Check the configuration file

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in Spanish
- [ ] I Ran a spell check
